### PR TITLE
Ensure it Works With `wakatime-lsp` Github Released Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Wakatime Client Plugin for Zed
 
-Uses @mrnossiom's [wakatime-lsp](https://github.com/mrnossiom/wakatime-lsp/) 
+Uses @mrnossiom's [wakatime-lsp](https://github.com/mrnossiom/wakatime-lsp/)
 
 ## Installation
 
 1. Install [wakatime-cli](https://github.com/wakatime/wakatime-cli)
-1. Install [wakatime-lsp](https://github.com/mrnossiom/wakatime-lsp)
-1. Clone this repo
-1. Open `zed: extensions` from the command palette
-1. Choose <kbd>Install dev extension</kbd>
-1. Choose the directory where you cloned this repo
-
+2. Clone this repo
+3. Open `zed: extensions` from the command palette
+4. Choose <kbd>Install dev extension</kbd>
+5. Choose the directory where you cloned this repo

--- a/extension.toml
+++ b/extension.toml
@@ -3,7 +3,7 @@ name = "Wakatime"
 version = "0.1.0"
 schema_version = 1
 authors = ["Ewen Le Bihan <hey@ewen.works>", "Rodney Osodo <socials@rodneyosodo.com>"]
-description = "Wakatime extension for Zed is a fully automatic time tracking tool for programmers using https://wakatime.com."
+description = "Wakatime extension for Zed provides automatic time tracking tool for programmers using https://wakatime.com."
 repository = "https://github.com/ewen-lbh/zed-wakatime"
 
 [language_servers.wakatime]

--- a/extension.toml
+++ b/extension.toml
@@ -1,9 +1,9 @@
 id = "wakatime"
 name = "Wakatime"
-version = "0.0.1"
+version = "0.1.0"
 schema_version = 1
-authors = ["Ewen Le Bihan <hey@ewen.works>"]
-description = "Wakatime support"
+authors = ["Ewen Le Bihan <hey@ewen.works>", "Rodney Osodo <socials@rodneyosodo.com>"]
+description = "Wakatime extension for Zed is a fully automatic time tracking tool for programmers using https://wakatime.com."
 repository = "https://github.com/ewen-lbh/zed-wakatime"
 
 [language_servers.wakatime]

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -1,13 +1,5 @@
-use std::fs::{self, OpenOptions};
-// use std::io::{prelude::*};
-
-use zed_extension_api::{self as zed, LanguageServerId, Result};
-
-fn log(msg: String) {
-    println!("{}", msg);
-    // let mut logfile = OpenOptions::new().write(true).append(true).open("/home/uwun/projects.local/zed-wakatime/ext.log").unwrap();
-    // writeln!(logfile, "{}", msg).unwrap();
-}
+use std::fs;
+use zed_extension_api::{self as zed};
 
 struct WakatimeExtension {
     cached_binary_path: Option<String>,
@@ -16,13 +8,10 @@ struct WakatimeExtension {
 impl WakatimeExtension {
     fn language_server_binary_path(
         &mut self,
-        language_server_id: &LanguageServerId,
+        language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
-    ) -> Result<String> {
-        log(format!("searching for wakatime-lsp"));
+    ) -> zed::Result<String> {
         if let Some(path) = worktree.which("wakatime-lsp") {
-            // !("found wakatime-lsp at {:?}", path);
-            // write the above line to the logfile at ~/projects.local/zed-wakatime/ext.log
             return Ok(path);
         }
 
@@ -34,14 +23,9 @@ impl WakatimeExtension {
 
         zed::set_language_server_installation_status(
             &language_server_id,
-            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+            &zed_extension_api::LanguageServerInstallationStatus::CheckingForUpdate,
         );
-
-        // Waiting on https://github.com/mrnossiom/wakatime-lsp/issues/2
-        unimplemented!(
-            "Use installation instructions on https://github.com/mrnossiom/wakatime-lsp"
-        );
-
+        
         let release = zed::latest_github_release(
             "mrnossiom/wakatime-lsp",
             zed::GithubReleaseOptions {
@@ -52,10 +36,10 @@ impl WakatimeExtension {
 
         let (platform, arch) = zed::current_platform();
         let asset_name = format!(
-            "wakatime-lsp-{arch}-{os}.tar.gz",
+            "wakatime-lsp-{arch}-{os}.{extension}",
             arch = match arch {
                 zed::Architecture::Aarch64 => "aarch64",
-                zed::Architecture::X86 => "x86",
+                zed::Architecture::X86 => "i386",
                 zed::Architecture::X8664 => "x86_64",
             },
             os = match platform {
@@ -63,6 +47,10 @@ impl WakatimeExtension {
                 zed::Os::Linux => "unknown-linux-gnu",
                 zed::Os::Windows => "pc-windows-msvc",
             },
+            extension = match platform {
+                zed::Os::Mac | zed::Os::Linux => "tar.gz",
+                zed::Os::Windows => "zip",
+            }
         );
 
         let asset = release
@@ -72,7 +60,8 @@ impl WakatimeExtension {
             .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
 
         let version_dir = format!("wakatime-lsp-{}", release.version);
-        let binary_path: String = todo!(); // format!("{version_dir}/wakatime-lsp-server");
+        let asset_name = asset_name.split('.').next().unwrap();
+        let binary_path: String = format!("{version_dir}/{asset_name}/wakatime-lsp");
 
         if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
             zed::set_language_server_installation_status(
@@ -83,9 +72,14 @@ impl WakatimeExtension {
             zed::download_file(
                 &asset.download_url,
                 &version_dir,
-                zed::DownloadedFileType::GzipTar,
+                match platform {
+                    zed::Os::Mac | zed::Os::Linux => zed::DownloadedFileType::GzipTar,
+                    zed::Os::Windows => zed::DownloadedFileType::Zip,
+                },
             )
             .map_err(|e| format!("failed to download file: {e}"))?;
+
+            zed::make_file_executable(&binary_path)?;
 
             let entries =
                 fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
@@ -104,7 +98,6 @@ impl WakatimeExtension {
 
 impl zed::Extension for WakatimeExtension {
     fn new() -> Self {
-        log(format!("new"));
         Self {
             cached_binary_path: None,
         }
@@ -112,34 +105,16 @@ impl zed::Extension for WakatimeExtension {
 
     fn language_server_command(
         &mut self,
-        language_server_id: &LanguageServerId,
+        language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
-    ) -> Result<zed::Command> {
-        log(format!("srvcmd @ server_id: {:?}", language_server_id));
+    ) -> zed::Result<zed::Command> {
+        let wakatime_language_server_binary_path =
+            self.language_server_binary_path(language_server_id, worktree)?;
         Ok(zed::Command {
-            command: self.language_server_binary_path(language_server_id, worktree)?,
+            command: wakatime_language_server_binary_path,
             args: vec![],
-            env: vec![
-                ("SCLS_CONFIG_SUBDIRECTORY".to_owned(), "zed".to_owned()),
-                ("RUST_LOG".to_owned(), "debug".to_owned()),
-            ],
-            // env: vec![],
+            env: vec![],
         })
-    }
-
-    fn language_server_workspace_configuration(
-        &mut self,
-        server_id: &LanguageServerId,
-        worktree: &zed_extension_api::Worktree,
-    ) -> Result<Option<zed_extension_api::serde_json::Value>> {
-        log(format!("wkspconf @ server_id: {:?}", server_id));
-        Ok(None)
-        // Ok(Some(
-        //     LspSettings::for_worktree("wakatime-lsp", worktree)
-        //         .ok()
-        //         .and_then(|settings| settings.settings.clone())
-        //         .unwrap(),
-        // ))
     }
 }
 

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -60,7 +60,7 @@ impl WakatimeExtension {
             .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
 
         let version_dir = format!("wakatime-lsp-{}", release.version);
-        let asset_name = asset_name.split('.').next().unwrap();
+        let asset_name = asset_name.split('.').next().expect("failed to split asset name");
         let binary_path: String = format!("{version_dir}/{asset_name}/wakatime-lsp");
 
         if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
@@ -79,7 +79,7 @@ impl WakatimeExtension {
             )
             .map_err(|e| format!("failed to download file: {e}"))?;
 
-            zed::make_file_executable(&binary_path)?;
+            zed::make_file_executable(&binary_path).expect("failed to make file executable");
 
             let entries =
                 fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
@@ -108,10 +108,8 @@ impl zed::Extension for WakatimeExtension {
         language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> zed::Result<zed::Command> {
-        let wakatime_language_server_binary_path =
-            self.language_server_binary_path(language_server_id, worktree)?;
         Ok(zed::Command {
-            command: wakatime_language_server_binary_path,
+            command: self.language_server_binary_path(language_server_id, worktree)?,
             args: vec![],
             env: vec![],
         })

--- a/src/wakatime.rs
+++ b/src/wakatime.rs
@@ -39,8 +39,8 @@ impl WakatimeExtension {
             "wakatime-lsp-{arch}-{os}.{extension}",
             arch = match arch {
                 zed::Architecture::Aarch64 => "aarch64",
-                zed::Architecture::X86 => "i386",
                 zed::Architecture::X8664 => "x86_64",
+                _ => return Err(format!("unsupported architecture: {:?}", arch)),
             },
             os = match platform {
                 zed::Os::Mac => "apple-darwin",


### PR DESCRIPTION
The changes, include the refactoring of method signatures within the `WakatimeExtension` struct to align with the changes in the `zed_extension_api`. Logging and unimplemented code sections were removed, and the binary path generation logic was improved. Additionally, the extension's version number was incremented in the `extension.toml` file, and the authorship details were updated.

## New Features

  - Updated the `extension.toml` file to version 0.1.0.
  - Added Rodney Osodo as an author alongside Ewen Le Bihan.
  - Expanded the description of the Wakatime extension for Zed to provide more details on its functionality.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the Wakatime extension for Zed by incrementing its version, adding a new author, and enhancing the description. It also includes refactoring to align with the `zed_extension_api` changes, improves binary path generation logic, and removes unnecessary logging and unimplemented code.

- **New Features**:
    - Updated the `extension.toml` file to version 0.1.0.
    - Added Rodney Osodo as an author alongside Ewen Le Bihan.
    - Expanded the description of the Wakatime extension for Zed to provide more details on its functionality.
- **Enhancements**:
    - Refactored method signatures within the `WakatimeExtension` struct to align with changes in the `zed_extension_api`.
    - Improved binary path generation logic for the Wakatime language server.
- **Chores**:
    - Removed logging and unimplemented code sections from `wakatime.rs`.

<!-- Generated by sourcery-ai[bot]: end summary -->